### PR TITLE
Updates and potential syntax adjustments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-language: objective-c
-before_script:
-    - brew update && brew upgrade xctool
+language: swift
+osx_image: xcode7.2
 xcode_project: JsonSerializer.xcodeproj
 xcode_scheme: JsonSerializerTests
 xcode_sdk: iphonesimulator

--- a/JsonSerializer.xcodeproj/project.pbxproj
+++ b/JsonSerializer.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 			attributes = {
 				LastSwiftMigration = 0720;
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Fuji Goro";
 				TargetAttributes = {
 					FA06004A19C10B7900B4A852 = {
@@ -505,6 +505,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -581,7 +582,9 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JsonSerializer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -597,7 +600,9 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JsonSerializer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -616,6 +621,7 @@
 				);
 				INFOPLIST_FILE = JsonSerializerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -630,6 +636,7 @@
 				);
 				INFOPLIST_FILE = JsonSerializerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -646,6 +653,7 @@
 				);
 				INFOPLIST_FILE = SwiftFeed/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -656,6 +664,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SwiftFeed/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -676,6 +685,7 @@
 				INFOPLIST_FILE = SwiftFeedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftFeed.app/SwiftFeed";
 			};
@@ -692,6 +702,7 @@
 				INFOPLIST_FILE = SwiftFeedTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftFeed.app/SwiftFeed";
 			};

--- a/JsonSerializer.xcodeproj/project.pbxproj
+++ b/JsonSerializer.xcodeproj/project.pbxproj
@@ -652,6 +652,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SwiftFeed/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -663,6 +664,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = SwiftFeed/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/JsonSerializer.xcodeproj/project.pbxproj
+++ b/JsonSerializer.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		FA06004219C10B7900B4A852 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0720;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = "Fuji Goro";
 				TargetAttributes = {

--- a/JsonSerializer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/JsonSerializer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/JsonSerializer.xcodeproj/xcshareddata/xcschemes/JsonSerializer.xcscheme
+++ b/JsonSerializer.xcodeproj/xcshareddata/xcschemes/JsonSerializer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,21 +23,24 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -52,10 +55,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/JsonSerializer.xcodeproj/xcshareddata/xcschemes/JsonSerializerTests.xcscheme
+++ b/JsonSerializer.xcodeproj/xcshareddata/xcschemes/JsonSerializerTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0600"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +48,18 @@
             ReferencedContainer = "container:JsonSerializer.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -71,10 +74,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/JsonSerializer/Info.plist
+++ b/JsonSerializer/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -154,7 +154,7 @@ extension Json {
 
 extension Json {
     public subscript(index: Int) -> Json? {
-        assert(index > 0)
+        assert(index >= 0)
         guard let array = arrayValue where index < array.count else { return nil }
         return array[index]
     }

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -60,6 +60,22 @@ public enum Json: CustomStringConvertible, CustomDebugStringConvertible, Equatab
     }
 }
 
+// MARK: Serialization
+
+extension Json {
+    public static func deserialize(source: String) throws -> Json {
+        return try JsonDeserializer(source.utf8).deserialize()
+    }
+    
+    public static func deserialize(source: [UInt8]) throws -> Json {
+        return try JsonDeserializer(source).deserialize()
+    }
+    
+    public static func deserialize<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>(sequence: ByteSequence) throws -> Json {
+        return try JsonDeserializer(sequence).deserialize()
+    }
+}
+
 // MARK: Convenience
 
 extension Json {

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -121,7 +121,7 @@ extension Json {
     }
 
     public var intValue: Int? {
-        guard case let .NumberValue(double) = self where double == Double(Int(double)) else {
+        guard case let .NumberValue(double) = self where Float80(double) == Float80(IntMax(double)) else {
             return nil
         }
         

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -121,7 +121,7 @@ extension Json {
     }
 
     public var intValue: Int? {
-        guard case let .NumberValue(double) = self where Float80(double) == Float80(IntMax(double)) else {
+        guard case let .NumberValue(double) = self where double % 1 == 0 else {
             return nil
         }
         

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -17,45 +17,45 @@ public enum Json: CustomStringConvertible, CustomDebugStringConvertible, Equatab
 
     // MARK: Initialization
     
-    init(_ value: Bool) {
+    public init(_ value: Bool) {
         self = .BooleanValue(value)
     }
     
-    init(_ value: Double) {
+    public init(_ value: Double) {
         self = .NumberValue(value)
     }
     
-    init(_ value: String) {
+    public init(_ value: String) {
         self = .StringValue(value)
     }
     
-    init(_ value: [Json]) {
+    public init(_ value: [Json]) {
         self = .ArrayValue(value)
     }
     
-    init(_ value: [String : Json]) {
+    public init(_ value: [String : Json]) {
         self = .ObjectValue(value)
     }
     
     // MARK: From
     
-    static func from(value: Bool) -> Json {
+    public static func from(value: Bool) -> Json {
         return .BooleanValue(value)
     }
 
-    static func from(value: Double) -> Json {
+    public static func from(value: Double) -> Json {
         return .NumberValue(value)
     }
 
-    static func from(value: String) -> Json {
+    public static func from(value: String) -> Json {
         return .StringValue(value)
     }
 
-    static func from(value: [Json]) -> Json {
+    public static func from(value: [Json]) -> Json {
         return .ArrayValue(value)
     }
 
-    static func from(value: [String : Json]) -> Json {
+    public static func from(value: [String : Json]) -> Json {
         return .ObjectValue(value)
     }
 }

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -112,6 +112,11 @@ extension Json {
         return bool
     }
 
+    public var floatValue: Float? {
+        guard let double = doubleValue else { return nil }
+        return Float(double)
+    }
+    
     public var doubleValue: Double? {
         guard case let .NumberValue(double) = self else {
             return nil
@@ -160,8 +165,16 @@ extension Json {
     }
 
     public subscript(key: String) -> Json? {
-        guard let dict = objectValue else { return nil }
-        return dict[key]
+        get {
+            guard let dict = objectValue else { return nil }
+            return dict[key]
+        }
+        set {
+            guard let object = objectValue else { fatalError("Unable to set string subscript on non-object type!") }
+            var mutableObject = object
+            mutableObject[key] = newValue
+            self = .from(mutableObject)
+        }
     }
 }
 

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -76,6 +76,26 @@ extension Json {
     }
 }
 
+extension Json {
+    public enum SerializationStyle {
+        case Default
+        case PrettyPrint
+        
+        private var serializer: JsonSerializer.Type {
+            switch self {
+            case .Default:
+                return DefaultJsonSerializer.self
+            case .PrettyPrint:
+                return PrettyJsonSerializer.self
+            }
+        }
+    }
+    
+    public func serialize(style: SerializationStyle = .Default) -> String {
+        return style.serializer.init().serialize(self)
+    }
+}
+
 // MARK: Convenience
 
 extension Json {

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -146,9 +146,9 @@ extension Json {
         return array
     }
 
-    public var dictionaryValue: [String : Json]? {
-        guard case let .ObjectValue(dictionary) = self else { return nil }
-        return dictionary
+    public var objectValue: [String : Json]? {
+        guard case let .ObjectValue(object) = self else { return nil }
+        return object
     }
 }
 
@@ -160,7 +160,7 @@ extension Json {
     }
 
     public subscript(key: String) -> Json? {
-        guard let dict = dictionaryValue else { return nil }
+        guard let dict = objectValue else { return nil }
         return dict[key]
     }
 }
@@ -199,7 +199,7 @@ public func ==(lhs: Json, rhs: Json) -> Bool {
         guard let rhsValue = rhs.arrayValue else { return false }
         return lhsValue == rhsValue
     case .ObjectValue(let lhsValue):
-        guard let rhsValue = rhs.dictionaryValue else { return false }
+        guard let rhsValue = rhs.objectValue else { return false }
         return lhsValue == rhsValue
     }
 }
@@ -255,13 +255,10 @@ extension Json: ArrayLiteralConvertible {
 
 extension Json: DictionaryLiteralConvertible {
     public init(dictionaryLiteral elements: (String, Json)...) {
-        var dictionary = [String:Json](minimumCapacity: elements.count)
-        for pair in elements {
-            dictionary[pair.0] = pair.1
+        var object = [String : Json](minimumCapacity: elements.count)
+        elements.forEach { key, value in
+            object[key] = value
         }
-        self = .ObjectValue(dictionary)
+        self = .ObjectValue(object)
     }
 }
-
-
-

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -8,7 +8,7 @@
 
 import func Darwin.atof
 
-public enum Json: Printable, DebugPrintable, Equatable {
+public enum Json: CustomStringConvertible, CustomDebugStringConvertible, Equatable {
     case NullValue
     case BooleanValue(Bool)
     case NumberValue(Double)

--- a/JsonSerializer/Json.swift
+++ b/JsonSerializer/Json.swift
@@ -105,11 +105,17 @@ extension Json {
     }
     
     public var boolValue: Bool? {
-        guard case let .BooleanValue(bool) = self else {
+        if case let .BooleanValue(bool) = self {
+            return bool
+        } else if let integer = intValue where integer == 1 || integer == 0 {
+            // When converting from foundation type `[String : AnyObject]`, something that I see as important, 
+            // it's not possible to distinguish between 'bool', 'double', and 'int'.
+            // Because of this, if we have an integer that is 0 or 1, and a user is requesting a boolean val,
+            // it's fairly likely this is their desired result.
+            return integer == 1
+        } else {
             return nil
         }
-        
-        return bool
     }
 
     public var floatValue: Float? {

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -67,7 +67,7 @@ struct PointerSequenceWrapper<T>: CollectionType {
 extension JsonParser {
     public static func parse(data: NSData) throws -> Json {
         let source = PointerSequenceWrapper<UInt8>(data)
-        let parser = GenJsonParser(source)
+        let parser = JsonParser(source)
         return try parser.parse()
     }
 }

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -65,7 +65,7 @@ struct PointerSequenceWrapper<T>: CollectionType {
 }
 
 extension JsonParser {
-    public static func parse(source: NSData) -> Result {
-        return GenericJsonParser<PointerSequenceWrapper<UInt8>>(PointerSequenceWrapper<UInt8>(source)).parse()
+    public static func parse(source: NSData) throws -> Json {
+        return try GenericJsonParser<PointerSequenceWrapper<UInt8>>(PointerSequenceWrapper<UInt8>(source)).parse()
     }
 }

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -6,6 +6,38 @@
 //  Copyright (c) 2014 Fuji Goro. All rights reserved.
 //
 
+import class Foundation.NSNull
+
+extension Json {
+    public static func from(any: AnyObject) -> Json {
+        switch any {
+            // If we're coming from foundation, it will be an `NSNumber`.
+            //This represents double, integer, and boolean.
+        case let number as Double:
+            return .NumberValue(number)
+        case let string as String:
+            return .StringValue(string)
+        case let object as [String : AnyObject]:
+            return from(object)
+        case let array as [AnyObject]:
+            return .ArrayValue(array.map(from))
+        case _ as NSNull:
+            return .NullValue
+        default:
+            fatalError("Unsupported foundation type")
+        }
+        return .NullValue
+    }
+    
+    public static func from(any: [String : AnyObject]) -> Json {
+        var mutable: [String : Json] = [:]
+        any.forEach { key, val in
+            mutable[key] = .from(val)
+        }
+        return .from(mutable)
+    }
+}
+
 import class Foundation.NSData
 
 extension Json {

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -8,66 +8,10 @@
 
 import class Foundation.NSData
 
-struct PointerGeneratorWrapper<T>: GeneratorType {
-    typealias Element = T
-
-    let ptr: PointerSequenceWrapper<T>
-    var cur: PointerSequenceWrapper<T>.Index
-
-    init(_ ptr: PointerSequenceWrapper<T>) {
-        self.ptr = ptr
-        self.cur = ptr.startIndex
-    }
-
-    mutating func next() -> Element? {
-        if cur != ptr.endIndex {
-            return ptr[cur]
-        } else {
-            return nil
-        }
-    }
-}
-
-struct PointerSequenceWrapper<T>: CollectionType {
-    typealias Generator = PointerGeneratorWrapper<T>
-    typealias Element = T
-    typealias Index = Int
-
-    let begin: UnsafePointer<Element>
-    let end: UnsafePointer<Element>
-
-    init(_ begin: UnsafePointer<Element>, _ end: UnsafePointer<Element>) {
-        self.begin = begin
-        self.end = end
-    }
-
-    init(_ source: NSData){
-        self.begin = unsafeBitCast(source.bytes, UnsafePointer<T>.self)
-        self.end = begin.advancedBy(source.length)
-    }
-
-    var startIndex: Index {
-        return 0
-    }
-
-    var endIndex: Index {
-        return begin.distanceTo(end)
-    }
-
-    subscript (position: Index) -> Generator.Element {
-        return begin.advancedBy(position).memory
-    }
-
-
-    func generate() -> Generator {
-        return PointerGeneratorWrapper<T>(self)
-    }
-}
-
-extension JsonParser {
-    public static func parse(data: NSData) throws -> Json {
-        let source = PointerSequenceWrapper<UInt8>(data)
-        let parser = JsonParser(source)
-        return try parser.parse()
+extension Json {
+    public static func deserialize(data: NSData) throws -> Json {
+        let startPointer = UnsafePointer<UInt8>(data.bytes)
+        let bufferPointer = UnsafeBufferPointer(start: startPointer, count: data.length)
+        return try deserialize(bufferPointer)
     }
 }

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -65,7 +65,10 @@ struct PointerSequenceWrapper<T>: CollectionType {
 }
 
 extension JsonParser {
-    public static func parse(source: NSData) throws -> Json {
-        return try GenericJsonParser<PointerSequenceWrapper<UInt8>>(PointerSequenceWrapper<UInt8>(source)).parse()
+    public static func parse(data: NSData) throws -> Json {
+        let ParserType = GenericJsonParser<PointerSequenceWrapper<UInt8>>.self
+        let source = PointerSequenceWrapper<UInt8>(data)
+        let parser = ParserType.init(source)
+        return try parser.parse()
     }
 }

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -67,6 +67,7 @@ struct PointerSequenceWrapper<T>: CollectionType {
 extension JsonParser {
     public static func parse(data: NSData) throws -> Json {
         let source = PointerSequenceWrapper<UInt8>(data)
-        return try JsonParser.parse(Array(source))
+        let parser = GenJsonParser(source)
+        return try parser.parse()
     }
 }

--- a/JsonSerializer/JsonParser+Foundation.swift
+++ b/JsonSerializer/JsonParser+Foundation.swift
@@ -66,9 +66,7 @@ struct PointerSequenceWrapper<T>: CollectionType {
 
 extension JsonParser {
     public static func parse(data: NSData) throws -> Json {
-        let ParserType = GenericJsonParser<PointerSequenceWrapper<UInt8>>.self
         let source = PointerSequenceWrapper<UInt8>(data)
-        let parser = ParserType.init(source)
-        return try parser.parse()
+        return try JsonParser.parse(Array(source))
     }
 }

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -184,11 +184,6 @@ internal final class JsonDeserializer: Parser {
             throw InvalidNumberError("invalid token in number", self)
         }
         
-        if integer != Int64(Float80(integer)) {
-            // TODO: Verify implications of Float80
-            throw InvalidNumberError("too much integer part in number", self)
-        }
-        
         var fraction: Double = 0.0
         if expect(".") {
             var factor = 0.1

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -41,7 +41,6 @@ public class GenericJsonParser<ByteSequence: CollectionType where ByteSequence.G
         let json = try parseValue()
         
         skipWhitespaces()
-//        print("\n\n\(cur) \n\n == \n\n \(end)\n\n")
         guard cur == end else {
             throw ExtraTokenError("extra tokens found", self)
         }
@@ -49,10 +48,7 @@ public class GenericJsonParser<ByteSequence: CollectionType where ByteSequence.G
     }
 
     func parseValue() throws -> Json {
-//        let c = Character(UnicodeScalar(currentChar))
-//        print("Current char: \(c)")
         skipWhitespaces()
-//        print("\(cur) == \(end)")
         if cur == end {
             throw InsufficientTokenError("unexpected end of tokens", self)
         }
@@ -350,7 +346,7 @@ public class GenericJsonParser<ByteSequence: CollectionType where ByteSequence.G
     func advance() {
         assert(cur != end, "out of range")
         cur++
-
+        
         if cur != end {
             switch currentChar {
             case Char(ascii: "\n"):
@@ -363,13 +359,20 @@ public class GenericJsonParser<ByteSequence: CollectionType where ByteSequence.G
     }
 
     func skipWhitespaces() {
-        LOOP: for ; cur != end; advance() {
-            switch currentChar {
-            case Char(ascii: " "), Char(ascii: "\t"), Char(ascii: "\r"), Char(ascii: "\n"):
-                break
-            default:
-                return
-            }
+        while cur != end && currentChar.isWhitespace {
+            advance()
+        }
+    }
+}
+
+extension GenericJsonParser.Char {
+    var isWhitespace: Bool {
+        let type = self.dynamicType
+        switch self {
+        case type.init(ascii: " "), type.init(ascii: "\t"), type.init(ascii: "\r"), type.init(ascii: "\n"):
+            return true
+        default:
+            return false
         }
     }
 }

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -9,14 +9,14 @@
 
 import func Darwin.pow
 
-public final class JsonDeserializer: Parser {
-    public typealias ByteSequence = [UInt8]
-    public typealias Char = UInt8
+internal final class JsonDeserializer: Parser {
+    internal  typealias ByteSequence = [UInt8]
+    internal  typealias Char = UInt8
     
     // MARK: Public Readable
     
-    public private(set) var lineNumber = 1
-    public private(set) var columnNumber = 1
+    internal private(set) var lineNumber = 1
+    internal private(set) var columnNumber = 1
     
     // MARK: Source
     
@@ -43,11 +43,11 @@ public final class JsonDeserializer: Parser {
     
     // MARK: Initializer
     
-    public required convenience init<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>(_ sequence: ByteSequence) {
+    internal required convenience init<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>(_ sequence: ByteSequence) {
         self.init(Array(sequence))
     }
     
-    public required init(_ source: ByteSequence) {
+    internal required init(_ source: ByteSequence) {
         self.source = source
         self.cur = source.startIndex
         self.end = source.endIndex
@@ -55,8 +55,8 @@ public final class JsonDeserializer: Parser {
     
     // MARK: Serialize
     
-    public func deserialize() throws -> Json {
-        let json = try parseValue()
+    internal func deserialize() throws -> Json {
+        let json = try deserializeNextValue()
         skipWhitespaces()
         
         guard cur == end else {
@@ -66,7 +66,7 @@ public final class JsonDeserializer: Parser {
         return json
     }
     
-    private func parseValue() throws -> Json {
+    private func deserializeNextValue() throws -> Json {
         skipWhitespaces()
         guard cur != end else {
             throw InsufficientTokenError("unexpected end of tokens", self)
@@ -250,7 +250,7 @@ public final class JsonDeserializer: Parser {
         var object = [String:Json]()
         
         while cur != end && !expect("}") {
-            guard case let .StringValue(key) = try parseValue() else {
+            guard case let .StringValue(key) = try deserializeNextValue() else {
                 throw NonStringKeyError("unexpected value for object key", self)
             }
             
@@ -260,7 +260,7 @@ public final class JsonDeserializer: Parser {
             }
             skipWhitespaces()
             
-            let value = try parseValue()
+            let value = try deserializeNextValue()
             object[key] = value
             
             skipWhitespaces()
@@ -285,7 +285,7 @@ public final class JsonDeserializer: Parser {
         var a = Array<Json>()
         
         LOOP: while cur != end && !expect("]") {
-            let json = try parseValue()
+            let json = try deserializeNextValue()
             skipWhitespaces()
             
             a.append(json)

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -9,10 +9,6 @@
 
 import func Darwin.pow
 
-enum Dummy : ErrorType {
-    case Error
-}
-
 public struct JsonParser {
     public static func parse(source: String) throws -> Json {
         return try GenJsonParser(source.utf8).parse()
@@ -315,7 +311,6 @@ public final class GenJsonParser: Parser {
             
         }
         
-        //        print("A: \(a)")
         return .ArrayValue(a)
     }
     
@@ -368,15 +363,14 @@ public final class GenJsonParser: Parser {
     private func advance() {
         assert(cur != end, "out of range")
         cur++
+        guard cur != end else { return }
         
-        if cur != end {
-            switch currentChar {
-            case Char(ascii: "\n"):
-                lineNumber++
-                columnNumber = 1
-            default:
-                columnNumber++
-            }
+        switch currentChar {
+        case Char(ascii: "\n"):
+            lineNumber++
+            columnNumber = 1
+        default:
+            columnNumber++
         }
     }
     

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -27,8 +27,8 @@ public struct JsonParser {
 }
 
 public class GenericJsonParser<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>: Parser {
-    typealias Source = ByteSequence
-    typealias Char = Source.Generator.Element
+    public typealias Source = ByteSequence
+    public typealias Char = Source.Generator.Element
 
     public typealias Result = ParseResult
 

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -9,17 +9,17 @@
 
 import func Darwin.pow
 
-public struct JsonParser {
+extension JsonParser {
     public static func parse(source: String) throws -> Json {
-        return try GenJsonParser(source.utf8).parse()
+        return try self.init(source.utf8).parse()
     }
     
     public static func parse(source: [UInt8]) throws -> Json {
-        return try GenJsonParser(source).parse()
+        return try self.init(source).parse()
     }
 }
 
-public final class GenJsonParser: Parser {
+public final class JsonParser: Parser {
     public typealias ByteSequence = [UInt8]
     public typealias Char = UInt8
     
@@ -381,7 +381,7 @@ public final class GenJsonParser: Parser {
     }
 }
 
-extension GenJsonParser.Char {
+extension JsonParser.Char {
     var isWhitespace: Bool {
         let type = self.dynamicType
         switch self {

--- a/JsonSerializer/JsonParser.swift
+++ b/JsonSerializer/JsonParser.swift
@@ -9,17 +9,7 @@
 
 import func Darwin.pow
 
-extension JsonParser {
-    public static func parse(source: String) throws -> Json {
-        return try self.init(source.utf8).parse()
-    }
-    
-    public static func parse(source: [UInt8]) throws -> Json {
-        return try self.init(source).parse()
-    }
-}
-
-public final class JsonParser: Parser {
+public final class JsonDeserializer: Parser {
     public typealias ByteSequence = [UInt8]
     public typealias Char = UInt8
     
@@ -53,11 +43,11 @@ public final class JsonParser: Parser {
     
     // MARK: Initializer
     
-    public convenience init<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>(_ sequence: ByteSequence) {
+    public required convenience init<ByteSequence: CollectionType where ByteSequence.Generator.Element == UInt8>(_ sequence: ByteSequence) {
         self.init(Array(sequence))
     }
     
-    public init(_ source: ByteSequence) {
+    public required init(_ source: ByteSequence) {
         self.source = source
         self.cur = source.startIndex
         self.end = source.endIndex
@@ -65,7 +55,7 @@ public final class JsonParser: Parser {
     
     // MARK: Serialize
     
-    public func parse() throws -> Json {
+    public func deserialize() throws -> Json {
         let json = try parseValue()
         skipWhitespaces()
         
@@ -378,7 +368,7 @@ public final class JsonParser: Parser {
     }
 }
 
-extension JsonParser.Char {
+extension JsonDeserializer.Char {
     var isWhitespace: Bool {
         let type = self.dynamicType
         switch self {

--- a/JsonSerializer/JsonSerializer.swift
+++ b/JsonSerializer/JsonSerializer.swift
@@ -6,13 +6,16 @@
 //  Copyright (c) 2014年 Fuji Goro. All rights reserved.
 //
 
-
 public protocol JsonSerializer {
+    init()
     func serialize(_: Json) -> String
 }
 
-public class DefaultJsonSerializer: JsonSerializer {
-    public func serialize(json: Json) -> String {
+internal class DefaultJsonSerializer: JsonSerializer {
+    
+    required init() {}
+    
+    internal func serialize(json: Json) -> String {
         switch json {
         case .NullValue:
             return "null"
@@ -59,10 +62,14 @@ public class DefaultJsonSerializer: JsonSerializer {
 
 }
 
-public class PrettyJsonSerializer: DefaultJsonSerializer {
+internal class PrettyJsonSerializer: DefaultJsonSerializer {
     private var indentLevel = 0
 
-    override public func serializeArray(array: [Json]) -> String {
+    required init() {
+        super.init()
+    }
+    
+    override internal func serializeArray(array: [Json]) -> String {
         indentLevel++
         defer {
             indentLevel--
@@ -80,7 +87,7 @@ public class PrettyJsonSerializer: DefaultJsonSerializer {
         return string + " ]"
     }
 
-    override public func serializeObject(object: [String : Json]) -> String {
+    override internal func serializeObject(object: [String : Json]) -> String {
         indentLevel++
         defer {
             indentLevel--

--- a/JsonSerializer/JsonSerializer.swift
+++ b/JsonSerializer/JsonSerializer.swift
@@ -8,7 +8,7 @@
 
 
 public protocol JsonSerializer {
-    func serialize(Json) -> String
+    func serialize(_: Json) -> String
 }
 
 public class DefaultJsonSerializer: JsonSerializer {
@@ -87,7 +87,7 @@ public class PrettyJsonSerializer: DefaultJsonSerializer {
         var i = 0
 
         var keys = o.keys.array
-        sort(&keys)
+        keys.sortInPlace()
         for key in keys {
             s += "\n"
             s += indent()

--- a/JsonSerializer/JsonSerializer.swift
+++ b/JsonSerializer/JsonSerializer.swift
@@ -81,23 +81,24 @@ public class PrettyJsonSerializer: DefaultJsonSerializer {
         return s + " ]"
     }
 
-    override public func serializeObject(o: [String:Json]) -> String {
-        var s = "{"
+    override public func serializeObject(object: [String:Json]) -> String {
         indentLevel++
-        var i = 0
-
-        var keys = o.keys.array
-        keys.sortInPlace()
-        for key in keys {
-            s += "\n"
-            s += indent()
-            s += "\(escapeAsJsonString(key)): \(o[key]!.serialize(self))"
-            if i++ != (o.count - 1) {
-                s += ","
-            }
+        defer {
+            indentLevel--
         }
-        indentLevel--
-        return s + " }"
+        
+        var string = "{\n"
+        let indentString = indent()
+        string += object
+            .map { key, val in
+                let escapedKey = escapeAsJsonString(key)
+                let serializedValue = val.serialize(self)
+                let serializedLine = "\(escapedKey): \(serializedValue)"
+                return indentString + serializedLine
+            }
+            .joinWithSeparator(",\n")
+        
+        return string + " }"
     }
 
     func indent() -> String {

--- a/JsonSerializer/JsonSerializer.swift
+++ b/JsonSerializer/JsonSerializer.swift
@@ -37,58 +37,61 @@ public class DefaultJsonSerializer: JsonSerializer {
         }
     }
 
-    func serializeArray(a: [Json]) -> String {
-        var s = "["
-        for var i = 0; i < a.count; i++ {
-            s += a[i].serialize(self)
-            if i != (a.count - 1) {
-                s += ","
+    func serializeArray(array: [Json]) -> String {
+        var string = "["
+        string += array
+            .map { val in
+                let serialized = val.serialize(self)
+                return indentString + serialized
             }
-        }
-        return s + "]"
+            .joinWithSeparator(",")
+        return string
     }
 
-    func serializeObject(o: [String:Json]) -> String {
-        var s = "{"
-        var i = 0
-        for entry in o {
-            s += "\(escapeAsJsonString(entry.0)):\(entry.1.serialize(self))"
-            if i++ != (o.count - 1) {
-                s += ","
+    func serializeObject(object: [String : Json]) -> String {
+        var string = "{"
+        string += object
+            .map { key, val in
+                let escapedKey = escapeAsJsonString(key)
+                let serializedVal = val.serialize(self)
+                return "\(escapedKey):\(serializedVal)"
             }
-        }
-
-        return s + "}"
+            .joinWithSeparator(",")
+        return string + "}"
     }
 
 }
 
 public class PrettyJsonSerializer: DefaultJsonSerializer {
-    var indentLevel = 0
+    private var indentLevel = 0
 
-    override public func serializeArray(a: [Json]) -> String {
-        var s = "["
-        indentLevel++
-        for var i = 0; i < a.count; i++ {
-            s += "\n"
-            s += indent()
-            s += a[i].serialize(self)
-            if i != (a.count - 1) {
-                s += ","
-            }
-        }
-        indentLevel--
-        return s + " ]"
-    }
-
-    override public func serializeObject(object: [String:Json]) -> String {
+    override public func serializeArray(array: [Json]) -> String {
         indentLevel++
         defer {
             indentLevel--
         }
         
-        var string = "{\n"
         let indentString = indent()
+        
+        var string = "[\n"
+        string += array
+            .map { val in
+                let serialized = val.serialize(self)
+                return indentString + serialized
+            }
+            .joinWithSeparator(",\n")
+        return string + " ]"
+    }
+
+    override public func serializeObject(object: [String : Json]) -> String {
+        indentLevel++
+        defer {
+            indentLevel--
+        }
+        
+        let indentString = indent()
+        
+        var string = "{\n"
         string += object
             .map { key, val in
                 let escapedKey = escapeAsJsonString(key)
@@ -97,15 +100,14 @@ public class PrettyJsonSerializer: DefaultJsonSerializer {
                 return indentString + serializedLine
             }
             .joinWithSeparator(",\n")
+        string += " }"
         
-        return string + " }"
+        return string
     }
 
     func indent() -> String {
-        var s = ""
-        for var i = 0; i < indentLevel; i++ {
-            s += "  "
-        }
-        return s
+        return Array(1...indentLevel)
+            .map { _ in "  " }
+            .joinWithSeparator("")
     }
 }

--- a/JsonSerializer/JsonSerializer.swift
+++ b/JsonSerializer/JsonSerializer.swift
@@ -40,12 +40,9 @@ public class DefaultJsonSerializer: JsonSerializer {
     func serializeArray(array: [Json]) -> String {
         var string = "["
         string += array
-            .map { val in
-                let serialized = val.serialize(self)
-                return indentString + serialized
-            }
+            .map { $0.serialize(self) }
             .joinWithSeparator(",")
-        return string
+        return string + "]"
     }
 
     func serializeObject(object: [String : Json]) -> String {

--- a/JsonSerializer/ParseError.swift
+++ b/JsonSerializer/ParseError.swift
@@ -11,7 +11,7 @@ protocol Parser {
     var columnNumber: Int { get }
 }
 
-public class ParseError: CustomStringConvertible {
+public class ParseError: ErrorType, CustomStringConvertible {
     public let reason: String
     let parser: Parser
 

--- a/JsonSerializer/ParseError.swift
+++ b/JsonSerializer/ParseError.swift
@@ -24,7 +24,7 @@ public class ParseError: CustomStringConvertible {
 
     public var description: String {
         get {
-            return "\(reflect(self).summary)[\(lineNumber):\(columnNumber)]: \(reason)"
+            return "\(Mirror(reflecting: self))[\(lineNumber):\(columnNumber)]: \(reason)"
         }
     }
 

--- a/JsonSerializer/ParseError.swift
+++ b/JsonSerializer/ParseError.swift
@@ -11,7 +11,7 @@ protocol Parser {
     var columnNumber: Int { get }
 }
 
-public class ParseError: Printable {
+public class ParseError: CustomStringConvertible {
     public let reason: String
     let parser: Parser
 

--- a/JsonSerializer/ParseError.swift
+++ b/JsonSerializer/ParseError.swift
@@ -16,16 +16,14 @@ public class ParseError: ErrorType, CustomStringConvertible {
     let parser: Parser
 
     public var lineNumber: Int {
-        get { return parser.lineNumber }
+        return parser.lineNumber
     }
     public var columnNumber: Int {
-        get { return parser.columnNumber }
+        return parser.columnNumber
     }
 
     public var description: String {
-        get {
-            return "\(Mirror(reflecting: self))[\(lineNumber):\(columnNumber)]: \(reason)"
-        }
+        return "\(Mirror(reflecting: self))[\(lineNumber):\(columnNumber)]: \(reason)"
     }
 
     init(_ reason: String, _ parser: Parser) {
@@ -33,7 +31,6 @@ public class ParseError: ErrorType, CustomStringConvertible {
         self.parser = parser
     }
 }
-
 
 public class UnexpectedTokenError: ParseError { }
 

--- a/JsonSerializer/StringUtils.swift
+++ b/JsonSerializer/StringUtils.swift
@@ -13,7 +13,7 @@ let unescapeMapping: [UnicodeScalar: UnicodeScalar] = [
 ]
 
 
-let escapeMapping: [Character: String] = [
+let escapeMapping: [Character : String] = [
     "\r": "\\r",
     "\n": "\\n",
     "\t": "\\t",
@@ -60,17 +60,13 @@ let digitMapping: [UnicodeScalar:Int] = [
 ]
 
 public func escapeAsJsonString(source : String) -> String {
-    var s = "\""
-
-    for c in source.characters {
-        if let escapedSymbol = escapeMapping[c] {
-            s.extend(escapedSymbol)
-        } else {
-            s.append(c)
-        }
+    var escapedString = "\""
+    source.characters.forEach { c in
+        let escapedChar = escapeMapping[c] ?? String(c)
+        escapedString += escapedChar
     }
-    s.extend("\"")
-    return s
+    escapedString += "\""
+    return escapedString
 }
 
 func digitToInt(b: UInt8) -> Int? {

--- a/JsonSerializer/StringUtils.swift
+++ b/JsonSerializer/StringUtils.swift
@@ -27,7 +27,7 @@ let escapeMapping: [Character : String] = [
     "\r\n": "\\r\\n",
 ]
 
-let hexMapping: [UnicodeScalar: UInt32] = [
+let hexMapping: [UnicodeScalar : UInt32] = [
     "0": 0x0,
     "1": 0x1,
     "2": 0x2,

--- a/JsonSerializer/StringUtils.swift
+++ b/JsonSerializer/StringUtils.swift
@@ -62,7 +62,7 @@ let digitMapping: [UnicodeScalar:Int] = [
 public func escapeAsJsonString(source : String) -> String {
     var s = "\""
 
-    for c in source {
+    for c in source.characters {
         if let escapedSymbol = escapeMapping[c] {
             s.extend(escapedSymbol)
         } else {

--- a/JsonSerializer/StringUtils.swift
+++ b/JsonSerializer/StringUtils.swift
@@ -12,7 +12,6 @@ let unescapeMapping: [UnicodeScalar: UnicodeScalar] = [
     "n": "\n",
 ]
 
-
 let escapeMapping: [Character : String] = [
     "\r": "\\r",
     "\n": "\\n",

--- a/JsonSerializer/StringUtils.swift
+++ b/JsonSerializer/StringUtils.swift
@@ -59,14 +59,17 @@ let digitMapping: [UnicodeScalar:Int] = [
     "9": 9,
 ]
 
-public func escapeAsJsonString(source : String) -> String {
-    var escapedString = "\""
-    source.characters.forEach { c in
-        let escapedChar = escapeMapping[c] ?? String(c)
-        escapedString += escapedChar
+extension String {
+    public var escapedJsonString: String {
+        let mapped = characters
+            .map { escapeMapping[$0] ?? String($0) }
+            .joinWithSeparator("")
+        return "\"" + mapped + "\""
     }
-    escapedString += "\""
-    return escapedString
+}
+
+public func escapeAsJsonString(source : String) -> String {
+    return source.escapedJsonString
 }
 
 func digitToInt(b: UInt8) -> Int? {

--- a/JsonSerializerTests/Info.plist
+++ b/JsonSerializerTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -26,7 +26,7 @@ class JsonParserTests: XCTestCase {
     }
 
     func testArrayWithSpaces() {
-        let json = try! JsonParser.parse("[ true , false , null ]")
+        let json = try! JsonParser.parse("[ true ,     false , null ]")
         XCTAssertEqual(json.description, "[true,false,null]")
     }
 

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -8,101 +8,101 @@
 
 import XCTest
 
-class JsonParserTests: XCTestCase {
+class JsonDeserializerTests: XCTestCase {
 
     func testEmptyArray() {
-        let json = try! JsonParser.parse("[]")
+        let json = try! Json.deserialize("[]")
         XCTAssertEqual(json.description, "[]")
     }
 
     func testEmptyArrayWithSpaces() {
-        let json = try! JsonParser.parse(" [ ] ")
+        let json = try! Json.deserialize(" [ ] ")
         XCTAssertEqual(json.description, "[]")
     }
 
     func testArray() {
-        let json = try! JsonParser.parse("[true,false,null]")
+        let json = try! Json.deserialize("[true,false,null]")
         XCTAssertEqual(json.description, "[true,false,null]")
     }
 
     func testArrayWithSpaces() {
-        let json = try! JsonParser.parse("[ true ,     false , null ]")
+        let json = try! Json.deserialize("[ true ,     false , null ]")
         XCTAssertEqual(json.description, "[true,false,null]")
     }
 
     func testEmptyObject() {
-        let json = try! JsonParser.parse("{}")
+        let json = try! Json.deserialize("{}")
         XCTAssertEqual(json.description, "{}")
     }
 
     func testEmptyObjectWithSpace() {
-        let json = try! JsonParser.parse(" { } ")
+        let json = try! Json.deserialize(" { } ")
         XCTAssertEqual(json.description, "{}")
     }
 
     func testObject() {
-        let json = try! JsonParser.parse("{\"foo\":[\"bar\",\"baz\"]}")
+        let json = try! Json.deserialize("{\"foo\":[\"bar\",\"baz\"]}")
         XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
     }
 
     func testObjectWithWhiteSpaces() {
-        let json = try! JsonParser.parse(" { \"foo\" : [ \"bar\" , \"baz\" ] } ")
+        let json = try! Json.deserialize(" { \"foo\" : [ \"bar\" , \"baz\" ] } ")
         XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
     }
 
 
     func testString() {
-        let json = try! JsonParser.parse("[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
+        let json = try! Json.deserialize("[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
         XCTAssertEqual(json.description, "[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
     }
 
     func testStringWithMyltiBytes() {
-        let json = try! JsonParser.parse("[\"こんにちは\"]")
+        let json = try! Json.deserialize("[\"こんにちは\"]")
         XCTAssertEqual(json[0]!.stringValue, "こんにちは")
         XCTAssertEqual(json.description, "[\"こんにちは\"]")
     }
 
     func testStringWithMyltiUnicodeScalars() {
-        let json = try! JsonParser.parse("[\"江戸前🍣\"]")
+        let json = try! Json.deserialize("[\"江戸前🍣\"]")
         XCTAssertEqual(json[0]!.stringValue!, "江戸前🍣")
         XCTAssertEqual(json[0]!.description, "\"江戸前🍣\"")
         XCTAssertEqual(json.description, "[\"江戸前🍣\"]")
     }
 
     func testNumberOfInt() {
-        let json = try! JsonParser.parse("[0, 10, 234]")
+        let json = try! Json.deserialize("[0, 10, 234]")
         XCTAssertEqual(json.description, "[0,10,234]")
     }
 
     func testNumberOfFloat() {
-        let json = try! JsonParser.parse("[3.14, 0.035]")
+        let json = try! Json.deserialize("[3.14, 0.035]")
         XCTAssertEqual(json.description, "[3.14,0.035]")
     }
 
     func testNumberOfExponent() {
-        let json = try! JsonParser.parse("[1e2, 1e-2, 3.14e+01]")
+        let json = try! Json.deserialize("[1e2, 1e-2, 3.14e+01]")
         XCTAssertEqual(json[0]!.intValue, 100)
         XCTAssertEqual(json[1]!.doubleValue, 0.01)
         XCTAssertEqual("\(json[2]!.doubleValue!)", "31.4")
     }
 
     func testUnicodeEscapeSequences() {
-        let json = try! JsonParser.parse("[\"\\u003c \\u003e\"]")
+        let json = try! Json.deserialize("[\"\\u003c \\u003e\"]")
         XCTAssertEqual(json[0]!.stringValue!, "< >")
     }
 
     func testUnicodeEscapeSequencesWith32bitsUnicodeScalar() {
-        let json = try! JsonParser.parse("[\"\\u0001F363\"]")
+        let json = try! Json.deserialize("[\"\\u0001F363\"]")
         XCTAssertEqual(json[0]!.stringValue, "\u{0001F363}")
     }
 
     func testTwitterJson() {
-        let json = try! JsonParser.parse(complexJsonExample("tweets"))
+        let json = try! Json.deserialize(complexJsonExample("tweets"))
         XCTAssertEqual(json["statuses"]![0]!["id_str"]!.stringValue, "250075927172759552")
     }
 
     func testStackexchangeJson() {
-        let json = try! JsonParser.parse(complexJsonExample("stackoverflow-items"))
+        let json = try! Json.deserialize(complexJsonExample("stackoverflow-items"))
         XCTAssertEqual(json["items"]![0]!["view_count"]!.intValue, 18711)
     }
 
@@ -111,7 +111,7 @@ class JsonParserTests: XCTestCase {
         let jsonSource = complexJsonExample("tweets")
 
         self.measureBlock {
-            let _ = try! JsonParser.parse(jsonSource)
+            let _ = try! Json.deserialize(jsonSource)
         }
     }
 
@@ -119,7 +119,7 @@ class JsonParserTests: XCTestCase {
         let jsonSource = String(data: complexJsonExample("tweets"), encoding: NSUTF8StringEncoding)!
 
         self.measureBlock {
-            let _ = try! JsonParser.parse(jsonSource)
+            let _ = try! Json.deserialize(jsonSource)
         }
     }
 

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -58,14 +58,14 @@ class JsonParserTests: XCTestCase {
 
     func testStringWithMyltiBytes() {
         let json = try! JsonParser.parse("[\"こんにちは\"]")
-        XCTAssertEqual(json[0].stringValue, "こんにちは")
+        XCTAssertEqual(json[0]!.stringValue, "こんにちは")
         XCTAssertEqual(json.description, "[\"こんにちは\"]")
     }
 
     func testStringWithMyltiUnicodeScalars() {
         let json = try! JsonParser.parse("[\"江戸前🍣\"]")
-        XCTAssertEqual(json[0].stringValue, "江戸前🍣")
-        XCTAssertEqual(json[0].description, "\"江戸前🍣\"")
+        XCTAssertEqual(json[0]!.stringValue!, "江戸前🍣")
+        XCTAssertEqual(json[0]!.description, "\"江戸前🍣\"")
         XCTAssertEqual(json.description, "[\"江戸前🍣\"]")
     }
 
@@ -81,29 +81,29 @@ class JsonParserTests: XCTestCase {
 
     func testNumberOfExponent() {
         let json = try! JsonParser.parse("[1e2, 1e-2, 3.14e+01]")
-        XCTAssertEqual(json[0].stringValue, "100")
-        XCTAssertEqual(json[1].stringValue, "0.01")
-        XCTAssertEqual(json[2].stringValue, "31.4")
+        XCTAssertEqual(json[0]!.intValue, 100)
+        XCTAssertEqual(json[1]!.doubleValue, 0.01)
+        XCTAssertEqual("\(json[2]!.doubleValue!)", "31.4")
     }
 
     func testUnicodeEscapeSequences() {
         let json = try! JsonParser.parse("[\"\\u003c \\u003e\"]")
-        XCTAssertEqual(json[0].stringValue, "< >")
+        XCTAssertEqual(json[0]!.stringValue!, "< >")
     }
 
     func testUnicodeEscapeSequencesWith32bitsUnicodeScalar() {
         let json = try! JsonParser.parse("[\"\\u0001F363\"]")
-        XCTAssertEqual(json[0].stringValue, "\u{0001F363}")
+        XCTAssertEqual(json[0]!.stringValue, "\u{0001F363}")
     }
 
     func testTwitterJson() {
         let json = try! JsonParser.parse(complexJsonExample("tweets"))
-        XCTAssertEqual(json["statuses"][0]["id_str"].stringValue, "250075927172759552")
+        XCTAssertEqual(json["statuses"]![0]!["id_str"]!.stringValue, "250075927172759552")
     }
 
     func testStackexchangeJson() {
         let json = try! JsonParser.parse(complexJsonExample("stackoverflow-items"))
-        XCTAssertEqual(json["items"][0]["view_count"].stringValue, "18711")
+        XCTAssertEqual(json["items"]![0]!["view_count"]!.intValue, 18711)
     }
 
 

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -220,8 +220,8 @@ class JsonParserTests: XCTestCase {
 
         self.measureBlock {
             switch JsonParser.parse(jsonSource) {
-            case .Success(let json):
-                XCTAssertTrue(true)
+            case .Success(_):
+                break
             case .Error(let error):
                 XCTFail(error.description)
             }
@@ -233,8 +233,8 @@ class JsonParserTests: XCTestCase {
 
         self.measureBlock {
             switch JsonParser.parse(jsonSource) {
-            case .Success(let json):
-                XCTAssertTrue(true)
+            case .Success(_):
+                break
             case .Error(let error):
                 XCTFail(error.description)
             }
@@ -244,15 +244,8 @@ class JsonParserTests: XCTestCase {
     func testPerformanceExampleInJSONSerialization() {
         let jsonSource = complexJsonExample("tweets")
         self.measureBlock {
-            var error: NSError? = nil
-            let dict: AnyObject? = NSJSONSerialization.JSONObjectWithData(jsonSource, options: .MutableContainers, error: &error)
-
-            switch error {
-            case .None:
-                break
-            case .Some(let e):
-                XCTFail("error: \(e)")
-            }
+            let dict: AnyObject? = try! NSJSONSerialization
+                .JSONObjectWithData(jsonSource, options: .MutableContainers)
         }
     }
 

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -244,7 +244,7 @@ class JsonParserTests: XCTestCase {
     func testPerformanceExampleInJSONSerialization() {
         let jsonSource = complexJsonExample("tweets")
         self.measureBlock {
-            let dict: AnyObject? = try! NSJSONSerialization
+            let _: AnyObject? = try! NSJSONSerialization
                 .JSONObjectWithData(jsonSource, options: .MutableContainers)
         }
     }

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -116,7 +116,7 @@ class JsonParserTests: XCTestCase {
     }
 
     func testPerformanceExampleWithString() {
-        let jsonSource = NSString(data: complexJsonExample("tweets"), encoding: NSUTF8StringEncoding) as! String
+        let jsonSource = String(data: complexJsonExample("tweets"), encoding: NSUTF8StringEncoding)!
 
         self.measureBlock {
             let _ = try! JsonParser.parse(jsonSource)

--- a/JsonSerializerTests/JsonParserTests.swift
+++ b/JsonSerializerTests/JsonParserTests.swift
@@ -11,207 +11,99 @@ import XCTest
 class JsonParserTests: XCTestCase {
 
     func testEmptyArray() {
-        let x = JsonParser.parse("[]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[]")
+        XCTAssertEqual(json.description, "[]")
     }
 
     func testEmptyArrayWithSpaces() {
-        let x = JsonParser.parse(" [ ] ")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse(" [ ] ")
+        XCTAssertEqual(json.description, "[]")
     }
 
     func testArray() {
-        let x = JsonParser.parse("[true,false,null]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[true,false,null]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[true,false,null]")
+        XCTAssertEqual(json.description, "[true,false,null]")
     }
 
     func testArrayWithSpaces() {
-        let x = JsonParser.parse("[ true , false , null ]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[true,false,null]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[ true , false , null ]")
+        XCTAssertEqual(json.description, "[true,false,null]")
     }
 
     func testEmptyObject() {
-        let x = JsonParser.parse("{}")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "{}")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("{}")
+        XCTAssertEqual(json.description, "{}")
     }
 
     func testEmptyObjectWithSpace() {
-        let x = JsonParser.parse(" { } ")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "{}")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse(" { } ")
+        XCTAssertEqual(json.description, "{}")
     }
 
     func testObject() {
-        let x = JsonParser.parse("{\"foo\":[\"bar\",\"baz\"]}")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("{\"foo\":[\"bar\",\"baz\"]}")
+        XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
     }
 
     func testObjectWithWhiteSpaces() {
-        let x = JsonParser.parse(" { \"foo\" : [ \"bar\" , \"baz\" ] } ")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse(" { \"foo\" : [ \"bar\" , \"baz\" ] } ")
+        XCTAssertEqual(json.description, "{\"foo\":[\"bar\",\"baz\"]}")
     }
 
 
     func testString() {
-        let x = JsonParser.parse("[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
+        XCTAssertEqual(json.description, "[\"foo [\\t] [\\r] [\\n]] [\\\\] bar\"]")
     }
 
     func testStringWithMyltiBytes() {
-        let x = JsonParser.parse("[\"こんにちは\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json[0].stringValue, "こんにちは")
-            XCTAssertEqual(json.description, "[\"こんにちは\"]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[\"こんにちは\"]")
+        XCTAssertEqual(json[0].stringValue, "こんにちは")
+        XCTAssertEqual(json.description, "[\"こんにちは\"]")
     }
 
     func testStringWithMyltiUnicodeScalars() {
-        let x = JsonParser.parse("[\"江戸前🍣\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json[0].stringValue, "江戸前🍣")
-            XCTAssertEqual(json[0].description, "\"江戸前🍣\"")
-            XCTAssertEqual(json.description, "[\"江戸前🍣\"]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[\"江戸前🍣\"]")
+        XCTAssertEqual(json[0].stringValue, "江戸前🍣")
+        XCTAssertEqual(json[0].description, "\"江戸前🍣\"")
+        XCTAssertEqual(json.description, "[\"江戸前🍣\"]")
     }
 
     func testNumberOfInt() {
-        let x = JsonParser.parse("[0, 10, 234]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[0,10,234]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[0, 10, 234]")
+        XCTAssertEqual(json.description, "[0,10,234]")
     }
 
     func testNumberOfFloat() {
-        let x = JsonParser.parse("[3.14, 0.035]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json.description, "[3.14,0.035]")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[3.14, 0.035]")
+        XCTAssertEqual(json.description, "[3.14,0.035]")
     }
 
     func testNumberOfExponent() {
-        let x = JsonParser.parse("[1e2, 1e-2, 3.14e+01]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json[0].stringValue, "100")
-            XCTAssertEqual(json[1].stringValue, "0.01")
-            XCTAssertEqual(json[2].stringValue, "31.4")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[1e2, 1e-2, 3.14e+01]")
+        XCTAssertEqual(json[0].stringValue, "100")
+        XCTAssertEqual(json[1].stringValue, "0.01")
+        XCTAssertEqual(json[2].stringValue, "31.4")
     }
 
     func testUnicodeEscapeSequences() {
-        let x = JsonParser.parse("[\"\\u003c \\u003e\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json[0].stringValue, "< >")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[\"\\u003c \\u003e\"]")
+        XCTAssertEqual(json[0].stringValue, "< >")
     }
 
     func testUnicodeEscapeSequencesWith32bitsUnicodeScalar() {
-        let x = JsonParser.parse("[\"\\u0001F363\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json[0].stringValue, "\u{0001F363}")
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse("[\"\\u0001F363\"]")
+        XCTAssertEqual(json[0].stringValue, "\u{0001F363}")
     }
 
     func testTwitterJson() {
-        let x = JsonParser.parse(complexJsonExample("tweets"))
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json["statuses"][0]["id_str"].stringValue, "250075927172759552")
-
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse(complexJsonExample("tweets"))
+        XCTAssertEqual(json["statuses"][0]["id_str"].stringValue, "250075927172759552")
     }
 
     func testStackexchangeJson() {
-        let x = JsonParser.parse(complexJsonExample("stackoverflow-items"))
-        switch x {
-        case .Success(let json):
-            XCTAssertEqual(json["items"][0]["view_count"].stringValue, "18711")
-
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let json = try! JsonParser.parse(complexJsonExample("stackoverflow-items"))
+        XCTAssertEqual(json["items"][0]["view_count"].stringValue, "18711")
     }
 
 
@@ -219,12 +111,7 @@ class JsonParserTests: XCTestCase {
         let jsonSource = complexJsonExample("tweets")
 
         self.measureBlock {
-            switch JsonParser.parse(jsonSource) {
-            case .Success(_):
-                break
-            case .Error(let error):
-                XCTFail(error.description)
-            }
+            let _ = try! JsonParser.parse(jsonSource)
         }
     }
 
@@ -232,12 +119,7 @@ class JsonParserTests: XCTestCase {
         let jsonSource = NSString(data: complexJsonExample("tweets"), encoding: NSUTF8StringEncoding) as! String
 
         self.measureBlock {
-            switch JsonParser.parse(jsonSource) {
-            case .Success(_):
-                break
-            case .Error(let error):
-                XCTFail(error.description)
-            }
+            let _ = try! JsonParser.parse(jsonSource)
         }
     }
 

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -12,7 +12,7 @@ class JsonTests: XCTestCase {
 
     func testConvenienceConvertions() {
         do {
-            let json = try JsonParser.parse("[\"foo bar\", true, false]")
+            let json = try Json.deserialize("[\"foo bar\", true, false]")
             XCTAssertEqual(json.description, "[\"foo bar\",true,false]")
             
             XCTAssertEqual(json[0]!.stringValue!, "foo bar")
@@ -60,14 +60,14 @@ class JsonTests: XCTestCase {
     func testConvertFromArrayLiteral() {
         let a: Json = [nil, true, 10, "foo"]
 
-        let expected = try! JsonParser.parse("[null, true, 10, \"foo\"]")
+        let expected = try! Json.deserialize("[null, true, 10, \"foo\"]")
         XCTAssertEqual(a, expected)
     }
 
     func testConvertFromDictionaryLiteral() {
         let array: Json = ["foo": 10, "bar": true]
 
-        let expected = try! JsonParser.parse("{ \"foo\": 10, \"bar\": true }")
+        let expected = try! Json.deserialize("{ \"foo\": 10, \"bar\": true }")
         XCTAssertEqual(array, expected)
     }
 

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -122,7 +122,6 @@ class JsonTests: XCTestCase {
         XCTAssertEqual(b1, b1)
         XCTAssertNotEqual(b0, e)
         XCTAssertNotEqual(b0, b1)
-        XCTAssertNotEqual(b0, n0)
         XCTAssertNotEqual(b0, s0)
         XCTAssertNotEqual(b0, a0)
         XCTAssertNotEqual(b0, o0)

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -11,22 +11,20 @@ import XCTest
 class JsonTests: XCTestCase {
 
     func testConvenienceConvertions() {
-        let x = JsonParser.parse("[\"foo bar\", true, false]")
-
-        switch x {
-        case .Success(let json):
+        do {
+            let json = try JsonParser.parse("[\"foo bar\", true, false]")
             XCTAssertEqual(json.description, "[\"foo bar\",true,false]")
-
+            
             XCTAssertEqual(json[0].stringValue, "foo bar")
             XCTAssertEqual(json[1].boolValue, true)
             XCTAssertEqual(json[2].boolValue, false)
-
+            
             XCTAssertEqual(json[3].stringValue, "", "out of range")
             XCTAssertEqual(json[3][0].stringValue, "", "no such item")
             XCTAssertEqual(json["no such property"].stringValue, "", "no such property")
             XCTAssertEqual(json["no"]["such"]["property"].stringValue, "", "no such properties")
-        case .Error(let error):
-            XCTFail(error.description)
+        } catch {
+            XCTFail("\(error)")
         }
     }
 
@@ -62,23 +60,15 @@ class JsonTests: XCTestCase {
     func testConvertFromArrayLiteral() {
         let a: Json = [nil, true, 10, "foo"]
 
-        switch JsonParser.parse("[null, true, 10, \"foo\"]") {
-        case .Success(let expected):
-            XCTAssertEqual(a, expected)
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let expected = try! JsonParser.parse("[null, true, 10, \"foo\"]")
+        XCTAssertEqual(a, expected)
     }
 
     func testConvertFromDictionaryLiteral() {
-        let a: Json = ["foo": 10, "bar": true]
+        let array: Json = ["foo": 10, "bar": true]
 
-        switch JsonParser.parse("{ \"foo\": 10, \"bar\": true }") {
-        case .Success(let expected):
-            XCTAssertEqual(a, expected)
-        case .Error(let error):
-            XCTFail(error.description)
-        }
+        let expected = try! JsonParser.parse("{ \"foo\": 10, \"bar\": true }")
+        XCTAssertEqual(array, expected)
     }
 
     func testPrintable() {

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -82,13 +82,13 @@ class JsonTests: XCTestCase {
     }
 
     func testPrintable() {
-        let x: Printable = Json.from(true)
+        let x: CustomStringConvertible = Json.from(true)
 
         XCTAssertEqual(x.description, "true", "Printable#description")
     }
 
     func testDebugPrintable() {
-        let x: DebugPrintable = Json.from(true)
+        let x: CustomDebugStringConvertible = Json.from(true)
 
         XCTAssertEqual(x.debugDescription, "true", "DebugPrintable#debugDescription")
     }

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -15,14 +15,14 @@ class JsonTests: XCTestCase {
             let json = try JsonParser.parse("[\"foo bar\", true, false]")
             XCTAssertEqual(json.description, "[\"foo bar\",true,false]")
             
-            XCTAssertEqual(json[0].stringValue, "foo bar")
-            XCTAssertEqual(json[1].boolValue, true)
-            XCTAssertEqual(json[2].boolValue, false)
+            XCTAssertEqual(json[0]!.stringValue!, "foo bar")
+            XCTAssertEqual(json[1]!.boolValue!, true)
+            XCTAssertEqual(json[2]!.boolValue!, false)
             
-            XCTAssertEqual(json[3].stringValue, "", "out of range")
-            XCTAssertEqual(json[3][0].stringValue, "", "no such item")
-            XCTAssertEqual(json["no such property"].stringValue, "", "no such property")
-            XCTAssertEqual(json["no"]["such"]["property"].stringValue, "", "no such properties")
+            XCTAssertEqual(json[3]?.stringValue, nil, "out of range")
+            XCTAssertEqual(json[3]?[0]?.stringValue, nil, "no such item")
+            XCTAssertEqual(json["no such property"]?.stringValue, nil, "no such property")
+            XCTAssertEqual(json["no"]?["such"]?["property"]?.stringValue, nil, "no such properties")
         } catch {
             XCTFail("\(error)")
         }

--- a/JsonSerializerTests/JsonTests.swift
+++ b/JsonSerializerTests/JsonTests.swift
@@ -97,10 +97,10 @@ class JsonTests: XCTestCase {
         let x = Json.from([true, [ "foo": 1, "bar": 2 ], false])
         XCTAssertEqual(x.debugDescription,
             "[\n" +
-            "  true,\n" +
-            "  {\n" +
-            "    \"bar\": 2,\n" +
-            "    \"foo\": 1 },\n" +
+                "  true,\n" +
+                "  {\n" +
+                "    \"bar\": 2,\n" +
+                "    \"foo\": 1 },\n" +
             "  false ]",
             "PrettyJsonSerializer")
     }

--- a/JsonSerializerTests/ParseErrorTests.swift
+++ b/JsonSerializerTests/ParseErrorTests.swift
@@ -11,132 +11,126 @@ import XCTest
 class ParseErrorTests: XCTestCase {
 
     func testEmptyString() {
-        let x = JsonParser.parse("")
-
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("")
             XCTFail("not reached")
-        case .Error(let error):
-
-            XCTAssert(error is InsufficientTokenError, error.description)
+        } catch let error as InsufficientTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 1, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testUnexpectedToken() {
-        let x = JsonParser.parse("?")
-
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("?")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is UnexpectedTokenError, error.description)
+        } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 1, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testSourceLocation() {
-        let x = JsonParser.parse("[\n   ?")
-
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("[\n   ?")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is UnexpectedTokenError, error.description)
+        } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 2, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 5, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testExtraTokens() {
-        let x = JsonParser.parse("[] []")
-
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("[] []")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is ExtraTokenError, error.description)
+        } catch let error as ExtraTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 4, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
-
     }
 
     func testInvalidNumber() {
-        let x = JsonParser.parse("[ 10. ]")
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("[ 10. ]")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is InvalidNumberError, error.description)
+        } catch let error as InvalidNumberError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 6, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
 
     func testMissingDoubleQuote() {
-        let x = JsonParser.parse("[ \"foo, null ]")
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("[ \"foo, null ]")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is InvalidStringError, error.description)
+        } catch let error as InvalidStringError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 14, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testMissingEscapedChar() {
-        let x = JsonParser.parse("[ \"foo \\")
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("[ \"foo \\")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is InvalidStringError, error.description)
+        } catch let error as InvalidStringError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 8, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testMissingColon() {
-        let x = JsonParser.parse("{ \"foo\" ")
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("{ \"foo\" ")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is UnexpectedTokenError, error.description)
+        } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 8, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
     func testMissingObjecValue() {
-        let x = JsonParser.parse("{ \"foo\": ")
-        switch x {
-        case .Success(_):
+        do {
+            let _ = try JsonParser.parse("{ \"foo\": ")
             XCTFail("not reached")
-        case .Error(let error):
-            XCTAssert(error is InsufficientTokenError, error.description)
+        } catch let error as InsufficientTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
             XCTAssertEqual(error.columnNumber, 9, "columnNumbeer")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 
 
     func testInvalidEscapeSequence() {
-        return // TODO
-        let x = JsonParser.parse("[\"\\uFFFFFFFFFFFFFFFF\"]")
-
-        switch x {
-        case .Success(let json):
-            XCTFail("not reached: \(json)")
-        case .Error(let error):
-            XCTAssert(error is InvalidNumberError, error.description)
-            XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
-            XCTAssertEqual(error.columnNumber, 9, "columnNumbeer")
-        }
+        return // TODO:
+//        let x = JsonParser.parse("[\"\\uFFFFFFFFFFFFFFFF\"]")
+//
+//        switch x {
+//        case .Success(let json):
+//            XCTFail("not reached: \(json)")
+//        case .Error(let error):
+//            XCTAssert(error is InvalidNumberError, error.description)
+//            XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
+//            XCTAssertEqual(error.columnNumber, 9, "columnNumbeer")
+//        }
     }
 }

--- a/JsonSerializerTests/ParseErrorTests.swift
+++ b/JsonSerializerTests/ParseErrorTests.swift
@@ -12,7 +12,7 @@ class ParseErrorTests: XCTestCase {
 
     func testEmptyString() {
         do {
-            let _ = try JsonParser.parse("")
+            let _ = try Json.deserialize("")
             XCTFail("not reached")
         } catch let error as InsufficientTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -24,7 +24,7 @@ class ParseErrorTests: XCTestCase {
 
     func testUnexpectedToken() {
         do {
-            let _ = try JsonParser.parse("?")
+            let _ = try Json.deserialize("?")
             XCTFail("not reached")
         } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -36,7 +36,7 @@ class ParseErrorTests: XCTestCase {
 
     func testSourceLocation() {
         do {
-            let _ = try JsonParser.parse("[\n   ?")
+            let _ = try Json.deserialize("[\n   ?")
             XCTFail("not reached")
         } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 2, "lineNumbeer")
@@ -48,7 +48,7 @@ class ParseErrorTests: XCTestCase {
 
     func testExtraTokens() {
         do {
-            let _ = try JsonParser.parse("[] []")
+            let _ = try Json.deserialize("[] []")
             XCTFail("not reached")
         } catch let error as ExtraTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -60,7 +60,7 @@ class ParseErrorTests: XCTestCase {
 
     func testInvalidNumber() {
         do {
-            let _ = try JsonParser.parse("[ 10. ]")
+            let _ = try Json.deserialize("[ 10. ]")
             XCTFail("not reached")
         } catch let error as InvalidNumberError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -73,7 +73,7 @@ class ParseErrorTests: XCTestCase {
 
     func testMissingDoubleQuote() {
         do {
-            let _ = try JsonParser.parse("[ \"foo, null ]")
+            let _ = try Json.deserialize("[ \"foo, null ]")
             XCTFail("not reached")
         } catch let error as InvalidStringError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -85,7 +85,7 @@ class ParseErrorTests: XCTestCase {
 
     func testMissingEscapedChar() {
         do {
-            let _ = try JsonParser.parse("[ \"foo \\")
+            let _ = try Json.deserialize("[ \"foo \\")
             XCTFail("not reached")
         } catch let error as InvalidStringError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -97,7 +97,7 @@ class ParseErrorTests: XCTestCase {
 
     func testMissingColon() {
         do {
-            let _ = try JsonParser.parse("{ \"foo\" ")
+            let _ = try Json.deserialize("{ \"foo\" ")
             XCTFail("not reached")
         } catch let error as UnexpectedTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -109,7 +109,7 @@ class ParseErrorTests: XCTestCase {
 
     func testMissingObjecValue() {
         do {
-            let _ = try JsonParser.parse("{ \"foo\": ")
+            let _ = try Json.deserialize("{ \"foo\": ")
             XCTFail("not reached")
         } catch let error as InsufficientTokenError {
             XCTAssertEqual(error.lineNumber, 1, "lineNumbeer")
@@ -122,7 +122,7 @@ class ParseErrorTests: XCTestCase {
 
     func testInvalidEscapeSequence() {
         return // TODO:
-//        let x = JsonParser.parse("[\"\\uFFFFFFFFFFFFFFFF\"]")
+//        let x = JsonParser.deserialize("[\"\\uFFFFFFFFFFFFFFFF\"]")
 //
 //        switch x {
 //        case .Success(let json):

--- a/SwiftFeed/ApiClient.swift
+++ b/SwiftFeed/ApiClient.swift
@@ -28,7 +28,7 @@ class ApiClient {
             }
 
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                let result = JsonParser.parse(data);
+                let result = JsonParser.deserializedata);
 
                 dispatch_async(dispatch_get_main_queue()) {
                     switch result {

--- a/SwiftFeed/ApiClient.swift
+++ b/SwiftFeed/ApiClient.swift
@@ -13,7 +13,7 @@ class ApiClient {
 
     enum Result {
         case Success(Json)
-        case Error(NSError)
+        case Error(ErrorType)
     }
 
     func get(url: NSURL, completion: (Result) -> Void) {
@@ -22,26 +22,20 @@ class ApiClient {
 
         let session = NSURLSession.sharedSession()
         let task = session.dataTaskWithRequest(request) { (data, request, error) -> Void in
-            if (error != nil) {
-                completion(.Error(error))
+            if let err = error {
+                completion(.Error(err))
                 return
             }
 
             dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
-                let result = JsonParser.deserializedata);
-
-                dispatch_async(dispatch_get_main_queue()) {
-                    switch result {
-                    case .Success(let json):
-                        completion(.Success(json))
-                    case .Error(let error):
-                        NSLog("json: %@", NSString(data: data, encoding: NSUTF8StringEncoding)!);
-                        NSLog("json parse error: %@", error.description)
-                        completion(.Error(NSError(domain: "SwiftFeed.JsonParseError",
-                            code: 100,
-                            userInfo: ["parseError": error])))
+                guard let data = data else { return }
+                do {
+                    let result = try Json.deserialize(data);
+                    dispatch_async(dispatch_get_main_queue()) {
+                        completion(.Success(result))
                     }
-
+                } catch {
+                    completion(.Error(error))
                 }
             }
         }

--- a/SwiftFeed/DetailViewController.swift
+++ b/SwiftFeed/DetailViewController.swift
@@ -22,11 +22,14 @@ class DetailViewController: UIViewController, UIWebViewDelegate {
     }
 
     func configureView() {
-        title = detailItem["title"].stringValue
+        title = detailItem["title"]?.stringValue
 
-        let url = NSURL(string: detailItem["link"].stringValue)!
+        guard
+            let urlString = detailItem["link"]?.stringValue,
+            let url = NSURL(string: urlString)
+            else { return }
+        
         let request = NSURLRequest(URL: url)
-
         webView.loadRequest(request)
         webView.delegate = self
     }

--- a/SwiftFeed/Info.plist
+++ b/SwiftFeed/Info.plist
@@ -46,5 +46,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <!--Include to allow all connections (DANGER)-->
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/SwiftFeed/Info.plist
+++ b/SwiftFeed/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftFeedTests/Info.plist
+++ b/SwiftFeedTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.gfx.swift.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Hi @gfx 

Thanks for doing all the heavy lifting on this here json parser!  I noticed the library hadn't been updated in a while, and needed some cleanup to be compatible with current Swift.  Along the way, I made some contributions that hopefully you'll find useful, totally open to discussion.  Some of the things I changed were:

- Updating to latest Swift syntax
- Moving from `Result<T>` to `try-catch` for synchronous operations.
- Cohesive naming scheme serialize / deserialize
- Access control keeping serialization / deserialization associated w/ singular `Json` object
- Remove C style for loops / while loops (these are unsupported in future Swift versions)
- Simplifications regarding buffers

> Essentially, front loading some of the buffer parsing instead of doing it in parallel.  This adds slight overhead to unsuccessful operations, since there is some unnecessarily collected data.  I didn't notice a performance change in performance tests.

My main motivation for these changes is adding completely foundation independent support for my existing library: <a href="https://github.com/LoganWright/Genome">Genome</a>.  Unfortunately, even though I removed all Foundation references, there's still an inability to cast value types to `AnyObject` which was happening implicitly w/o foundation references and I didn't realize it.

As I said earlier, totally open to discussing the implications of some of these changes, and if necessary, I'm happy to maintain my changes in a separate fork.

### Going Forward

There's a few other things I'd like to get setup.

-  [ ] Cocoapods support

> I'm happy to do the podspec setup etc., but if you want to maintain ownership over the pod, you should be the one to push it to Trunk

- [ ] Package Support

> Once this library is setup for integration, I'd like to investigate supporting Swift Packages so that our libraries can be bundled that way.

Thanks again for getting this library going,

Logan